### PR TITLE
various refactoring across app

### DIFF
--- a/Habits.xcodeproj/project.pbxproj
+++ b/Habits.xcodeproj/project.pbxproj
@@ -9,6 +9,7 @@
 /* Begin PBXBuildFile section */
 		3CC551A27B6840B7BDF879AB /* Pods_Habits.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 838E44C3241E759CB1015ADF /* Pods_Habits.framework */; };
 		FA09DC1D26CF17E000B58F32 /* UIImage + Ext.swift in Sources */ = {isa = PBXBuildFile; fileRef = FA09DC1C26CF17E000B58F32 /* UIImage + Ext.swift */; };
+		FA0D65DF2829F0AD000DB768 /* TableViewFuncs.swift in Sources */ = {isa = PBXBuildFile; fileRef = FA0D65DE2829F0AD000DB768 /* TableViewFuncs.swift */; };
 		FA175EDC2754C8D80067D2A5 /* LoadingScreenVC.swift in Sources */ = {isa = PBXBuildFile; fileRef = FA175EDB2754C8D80067D2A5 /* LoadingScreenVC.swift */; };
 		FA1AB1C52822B69C0097A3AA /* NewHabitVC.swift in Sources */ = {isa = PBXBuildFile; fileRef = FA1AB1C42822B69C0097A3AA /* NewHabitVC.swift */; };
 		FA1C7306263636D800E63CBE /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = FA1C7305263636D800E63CBE /* AppDelegate.swift */; };
@@ -78,6 +79,7 @@
 		2FF57C4A93B664F2B8DAF532 /* Pods-Habits.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Habits.debug.xcconfig"; path = "Target Support Files/Pods-Habits/Pods-Habits.debug.xcconfig"; sourceTree = "<group>"; };
 		838E44C3241E759CB1015ADF /* Pods_Habits.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_Habits.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		FA09DC1C26CF17E000B58F32 /* UIImage + Ext.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIImage + Ext.swift"; sourceTree = "<group>"; };
+		FA0D65DE2829F0AD000DB768 /* TableViewFuncs.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TableViewFuncs.swift; sourceTree = "<group>"; };
 		FA175EDB2754C8D80067D2A5 /* LoadingScreenVC.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LoadingScreenVC.swift; sourceTree = "<group>"; };
 		FA1AB1C42822B69C0097A3AA /* NewHabitVC.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = NewHabitVC.swift; sourceTree = "<group>"; };
 		FA1C7302263636D800E63CBE /* Habits.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = Habits.app; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -323,6 +325,7 @@
 				FA224D5A26F028E6005CC9F1 /* Constants.swift */,
 				FA224D7026F1A1A9005CC9F1 /* FSCalendarView.swift */,
 				FA79D7662820F318004E0CAC /* SettingsFuncs.swift */,
+				FA0D65DE2829F0AD000DB768 /* TableViewFuncs.swift */,
 			);
 			path = Utilities;
 			sourceTree = "<group>";
@@ -534,6 +537,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				FA1D6D8326E729AB005AA4B2 /* Animations.swift in Sources */,
+				FA0D65DF2829F0AD000DB768 /* TableViewFuncs.swift in Sources */,
 				FA1C733026365AFC00E63CBE /* BodyLabel.swift in Sources */,
 				FAF4E714265F43270029E50D /* HowToUseVC.swift in Sources */,
 				FA360BF226C605C300884B90 /* HabitNameCell.swift in Sources */,

--- a/Habits/Cells/TableViewCells/NewHabitVCCells/HabitColorCell.swift
+++ b/Habits/Cells/TableViewCells/NewHabitVCCells/HabitColorCell.swift
@@ -46,9 +46,6 @@ class HabitColorCell: UITableViewCell {
         colorStack.axis          = .horizontal
         colorStack.distribution  = .fillEqually
         colorStack.spacing       = 6
-        
-        
-        
     }
     
     private func configureColorButtons() {

--- a/Habits/Utilities/DateModel.swift
+++ b/Habits/Utilities/DateModel.swift
@@ -82,4 +82,21 @@ class DateModel {
         let date                 = dateFormatter.string(from: dateCreated)
         return date
     }
+    
+    
+    ///Takes time from datepicker, converts it to string and splits hours and minutes into seperate strings for use in UserNotifications.
+    func convertDatePickerTime(date: Date) -> [String] {
+        let formatter = DateFormatter()
+        formatter.dateFormat = "h:mm a"
+        let dateAsString = formatter.string(from: date)
+        
+        let date = formatter.date(from: dateAsString)
+        formatter.dateFormat = "HH:mm"
+        
+        let twentyFourHourDate = formatter.string(from: date!)
+        let time = twentyFourHourDate.components(separatedBy: ":")
+        
+        return time
+    }
+    
 }

--- a/Habits/Utilities/TableViewFuncs.swift
+++ b/Habits/Utilities/TableViewFuncs.swift
@@ -1,0 +1,65 @@
+//
+//  TableViewFuncs.swift
+//  Habits
+//
+//  Created by Alexander Thompson on 10/5/2022.
+//
+
+import UIKit
+
+struct TableViewFuncs {
+    
+    enum selectedVC {
+        case HabitHomeVC
+        case NewHabitVC
+        case SideMenuVC
+        case AboutAppVC
+    }
+    
+    
+    /// User selects which VC & tableview they are calling this func for and it will apply numerous tableView settings which bloat up the main VC.
+    ///
+    /// ```
+    /// TableViewFuncs().setupTableView(for: .HabitHomeVC, using: tableView)
+    /// ```
+    ///
+    /// - Warning: TableViewDelegate and DataSource still need to be called in the view controller.
+    /// - Parameter selectedVC: enum to select which VC this method will apply to.
+    /// - Parameter tableView: which tableView this method will apply to.
+    func setupTableView(for viewController: selectedVC, using tableView: UITableView) {
+        switch viewController {
+        case .HabitHomeVC:
+            tableView.register(HabitCell.self, forCellReuseIdentifier: HabitCell.reuseID)
+            tableView.backgroundColor        = BackgroundColors.mainBackGround
+            tableView.separatorStyle         = .none
+            tableView.dragInteractionEnabled = true
+            
+        case .NewHabitVC:
+            tableView.backgroundColor = BackgroundColors.mainBackGround
+            tableView.allowsSelection = false
+            tableView.separatorStyle  = .none
+            tableView.register(HabitNameCell.self, forCellReuseIdentifier: HabitNameCell.reuseID)
+            tableView.register(HabitFrequencyCell.self, forCellReuseIdentifier: HabitFrequencyCell.reuseID)
+            tableView.register(HabitIconCell.self, forCellReuseIdentifier: HabitIconCell.reuseID)
+            tableView.register(HabitReminderCell.self, forCellReuseIdentifier: HabitReminderCell.reuseID)
+            tableView.register(HabitColorCell.self, forCellReuseIdentifier: HabitColorCell.reuseID)
+            tableView.register(HabitSaveCell.self, forCellReuseIdentifier: HabitSaveCell.reuseID)
+            
+        case .SideMenuVC:
+            tableView.backgroundColor    = BackgroundColors.secondaryBackground
+            tableView.estimatedRowHeight = 70
+            tableView.separatorStyle     = .none
+            tableView.register(MenuCell.self, forCellReuseIdentifier: MenuCell.reuseID)
+            
+        case .AboutAppVC:
+            tableView.separatorStyle     = .none
+            tableView.rowHeight          = 50
+            tableView.backgroundColor    = BackgroundColors.secondaryBackground
+            tableView.bounces            = false
+            tableView.layer.cornerRadius = 10
+            tableView.translatesAutoresizingMaskIntoConstraints = false
+            tableView.register(MenuCell.self, forCellReuseIdentifier: MenuCell.reuseID)
+        }
+    }
+    
+}

--- a/Habits/Utilities/UserNotifications.swift
+++ b/Habits/Utilities/UserNotifications.swift
@@ -83,6 +83,31 @@ class UserNotifications {
         }
     }
     
+    func dateSegmentChanged(segment: UISegmentedControl, vc: UIViewController) {
+        let current = UNUserNotificationCenter.current()
+        current.getNotificationSettings { (settings) in
+            if settings.authorizationStatus == .authorized {
+                DispatchQueue.main.async {
+                    segment.selectedSegmentIndex = 1
+                }
+            }
+            if settings.authorizationStatus == .denied {
+                let deniedAlert = UIAlertController(title: Labels.notificationDeniedTitle, message: Labels.notificationDeniedMessage, preferredStyle: .alert)
+                deniedAlert.addAction(UIAlertAction(title: "App Settings", style: .default, handler: { (alert) in
+                    if let appSettings = URL(string: UIApplication.openSettingsURLString), UIApplication.shared.canOpenURL(appSettings) {
+                        UIApplication.shared.open(appSettings)
+                    }
+                }))
+                deniedAlert.addAction(UIAlertAction(title: "Ok", style: .cancel, handler: nil))
+                DispatchQueue.main.async {
+                    vc.present(deniedAlert, animated: true) {
+                        segment.selectedSegmentIndex = 0
+                    }
+                }
+            }
+        }
+    }
+    
 }
 
 

--- a/Habits/ViewControllers/AboutAppVC.swift
+++ b/Habits/ViewControllers/AboutAppVC.swift
@@ -50,16 +50,10 @@ class AboutAppVC: UIViewController {
     
     
     private func configureTableView() {
+        TableViewFuncs().setupTableView(for: .AboutAppVC, using: tableView)
         tableView.delegate           = self
         tableView.dataSource         = self
-        tableView.separatorStyle     = .none
-        tableView.rowHeight          = 50
-        tableView.backgroundColor    = BackgroundColors.secondaryBackground
-        tableView.bounces            = false
-        tableView.layer.cornerRadius = 10
         tableView.frame.size.height  = tableView.contentSize.height
-        tableView.translatesAutoresizingMaskIntoConstraints = false
-        tableView.register(MenuCell.self, forCellReuseIdentifier: MenuCell.reuseID)
     }
     
     

--- a/Habits/ViewControllers/HabitHomeVC.swift
+++ b/Habits/ViewControllers/HabitHomeVC.swift
@@ -65,14 +65,11 @@ class HabitHomeVC: UIViewController, SettingsPush {
     
     private func configureTableView() {
         view.addSubview(tableView)
-        tableView.register(HabitCell.self, forCellReuseIdentifier: HabitCell.reuseID)
+        TableViewFuncs().setupTableView(for: .HabitHomeVC, using: tableView)
         tableView.delegate               = self
         tableView.dataSource             = self
-        tableView.frame                  = view.bounds
-        tableView.backgroundColor        = BackgroundColors.mainBackGround
-        tableView.separatorStyle         = .none
-        tableView.dragInteractionEnabled = true
         tableView.dragDelegate           = self
+        tableView.frame                  = view.bounds
     }
     
     ///Populates an array with quotes for tableview header.

--- a/Habits/ViewControllers/SideMenuVC.swift
+++ b/Habits/ViewControllers/SideMenuVC.swift
@@ -28,13 +28,10 @@ class SideMenuVC: UIViewController {
     }
     
     func configureTableView() {
-        tableView.backgroundColor    = BackgroundColors.secondaryBackground
+        TableViewFuncs().setupTableView(for: .SideMenuVC, using: tableView)
         tableView.frame              = view.bounds
         tableView.delegate           = self
         tableView.dataSource         = self
-        tableView.estimatedRowHeight = 70
-        tableView.separatorStyle     = .none
-        tableView.register(MenuCell.self, forCellReuseIdentifier: MenuCell.reuseID)
         view.addSubview(tableView)
     }
     


### PR DESCRIPTION
Rework tableView implementation to move a lot of initial tableview setup code to an external method to cut down on VC line size. 
move AddHabitVC DatePicker conversion code to external method. 

move AddHabitVC UIsegmentedControl UserNotifications settings to external method. 